### PR TITLE
Add hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "fgw_router",
+  "country": ["PT"]
+}


### PR DESCRIPTION
Adds a very basic [hacs.json](https://www.hacs.xyz/docs/publish/start/#hacsjson) file, which seems to now be mandatory.

Fixes the error during install "The version ec89680 for this integration can not be used with HACS."